### PR TITLE
[feature] #15 호스트_나의객실목록조회

### DIFF
--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
@@ -13,7 +13,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface LodgeService {
 
-    CreateLodgeResponseDto createLodge(CreateLodgeRequestDto request);
+    CreateLodgeResponseDto createLodge(CreateLodgeRequestDto request, UserInfo userInfo);
 
     GetLodgeResponseDto getLodge(UUID id);
 

--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
@@ -6,6 +6,7 @@ import com.fouribnb.lodge.presentation.dto.request.UpdateLodgeRequestDto;
 import com.fouribnb.lodge.presentation.dto.response.CreateLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.GetLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.UpdateLodgeResponseDto;
+import com.fourirbnb.common.security.UserInfo;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
@@ -24,5 +25,7 @@ public interface LodgeService {
     Page<GetLodgeResponseDto> getLodges(Pageable pageable);
 
     Void deleteLodge(UUID id);
+
+    Page<GetLodgeResponseDto> getHostLodges(Pageable pageable, UserInfo userInfo);
 
 }

--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeService.java
@@ -1,15 +1,12 @@
 package com.fouribnb.lodge.application.service;
 
-import com.fouribnb.lodge.domain.entity.Lodge;
 import com.fouribnb.lodge.presentation.dto.request.CreateLodgeRequestDto;
 import com.fouribnb.lodge.presentation.dto.request.UpdateLodgeRequestDto;
 import com.fouribnb.lodge.presentation.dto.response.CreateLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.GetLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.UpdateLodgeResponseDto;
 import com.fourirbnb.common.security.UserInfo;
-import java.util.List;
 import java.util.UUID;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -24,7 +21,7 @@ public interface LodgeService {
 
     Page<GetLodgeResponseDto> getLodges(Pageable pageable);
 
-    Void deleteLodge(UUID id);
+    Void deleteLodge(UUID id, UserInfo userInfo);
 
     Page<GetLodgeResponseDto> getHostLodges(Pageable pageable, UserInfo userInfo);
 

--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
@@ -56,12 +56,11 @@ public class LodgeServiceImpl implements LodgeService {
     }
 
     @Override
-    public Void deleteLodge(UUID id) {
+    public Void deleteLodge(UUID id, UserInfo userInfo) {
+        Long currentUserId = userInfo.getUserId();
         Lodge lodge = lodgeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("lodge를 찾을 수 없음"));
-//        lodge.delete(currentUserId);
-        lodge.delete(lodge.getHostId());
-        //todo. currentUserId 받아와서 입력
+        lodge.delete(currentUserId);
         lodgeRepository.save(lodge);
         return null;
     }

--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
@@ -25,8 +25,9 @@ public class LodgeServiceImpl implements LodgeService {
     private final LodgeRepository lodgeRepository;
 
     @Override
-    public CreateLodgeResponseDto createLodge(CreateLodgeRequestDto request) {
-        Lodge lodge = LodgeMapper.createToEntity(request);
+    public CreateLodgeResponseDto createLodge(CreateLodgeRequestDto request, UserInfo userInfo) {
+        Long currentHostId = userInfo.getUserId();
+        Lodge lodge = LodgeMapper.createToEntity(request, currentHostId);
         lodgeRepository.save(lodge);
         return LodgeMapper.createToResponse(lodge);
     }
@@ -67,8 +68,8 @@ public class LodgeServiceImpl implements LodgeService {
 
     @Override
     public Page<GetLodgeResponseDto> getHostLodges(Pageable pageable, UserInfo userInfo) {
-        Long currentUserId = userInfo.getUserId();
-        Page<GetLodgeResponseDto> dtos =  lodgeRepository.findAllByUserId(pageable, currentUserId)
+        Long currentHostId = userInfo.getUserId();
+        Page<GetLodgeResponseDto> dtos =  lodgeRepository.findAllByUserId(pageable, currentHostId)
                 .map(LodgeMapper::getToResponse);
         return dtos;
 

--- a/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
+++ b/src/main/java/com/fouribnb/lodge/application/service/LodgeServiceImpl.java
@@ -9,6 +9,7 @@ import com.fouribnb.lodge.presentation.dto.response.GetLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.UpdateLodgeResponseDto;
 import com.fouribnb.lodge.presentation.mapper.LodgeMapper;
 import com.fourirbnb.common.exception.ResourceNotFoundException;
+import com.fourirbnb.common.security.UserInfo;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,6 +32,7 @@ public class LodgeServiceImpl implements LodgeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public GetLodgeResponseDto getLodge(UUID id) {
         Lodge lodge = lodgeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("lodge를 찾을 수 없음"));
@@ -46,6 +48,7 @@ public class LodgeServiceImpl implements LodgeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<GetLodgeResponseDto> getLodges(Pageable pageable) {
         Page<GetLodgeResponseDto> dtos =  lodgeRepository.findAll(pageable)
                 .map(LodgeMapper::getToResponse);
@@ -61,6 +64,15 @@ public class LodgeServiceImpl implements LodgeService {
         //todo. currentUserId 받아와서 입력
         lodgeRepository.save(lodge);
         return null;
+    }
+
+    @Override
+    public Page<GetLodgeResponseDto> getHostLodges(Pageable pageable, UserInfo userInfo) {
+        Long currentUserId = userInfo.getUserId();
+        Page<GetLodgeResponseDto> dtos =  lodgeRepository.findAllByUserId(pageable, currentUserId)
+                .map(LodgeMapper::getToResponse);
+        return dtos;
+
     }
 
 

--- a/src/main/java/com/fouribnb/lodge/domain/entity/Lodge.java
+++ b/src/main/java/com/fouribnb/lodge/domain/entity/Lodge.java
@@ -78,14 +78,28 @@ public class Lodge extends BaseEntity {
         this.lodgeStatus = lodgeStatus;
     }
 
-    public void update(UpdateLodgeRequestDto requestDto) {
-        this.lodgeName = requestDto.getLodgeName();
-        this.roomType = requestDto.getRoomType();
-        this.capacity = requestDto.getCapacity();
-        this.address = requestDto.getAddress();
-        this.pricePerNight = requestDto.getPricePerNight();
-        this.description = requestDto.getDescription();
-        this.amenities = requestDto.getAmenities();
+    public void update(UpdateLodgeRequestDto dto) {
+        if(dto.getLodgeName() != null){
+            this.lodgeName = dto.getLodgeName();
+        }
+        if(dto.getRoomType() != null){
+            this.roomType = dto.getRoomType();
+        }
+        if(dto.getCapacity() != null){
+            this.capacity = dto.getCapacity();
+        }
+        if(dto.getAddress() != null){
+            this.address = dto.getAddress();
+        }
+        if(dto.getPricePerNight() != null){
+            this.pricePerNight = dto.getPricePerNight();
+        }
+        if(dto.getDescription() != null){
+            this.description = dto.getDescription();
+        }
+        if(dto.getLodgeName() != null){
+            this.amenities = dto.getAmenities();
+        }
     }
 
 }

--- a/src/main/java/com/fouribnb/lodge/domain/repository/LodgeRepository.java
+++ b/src/main/java/com/fouribnb/lodge/domain/repository/LodgeRepository.java
@@ -13,4 +13,6 @@ public interface LodgeRepository {
     Optional<Lodge> findById(UUID id);
 
     Page<Lodge> findAll(Pageable pageable);
+
+    Page<Lodge> findAllByUserId(Pageable pageable, Long currentUserId);
 }

--- a/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
@@ -8,6 +8,9 @@ import com.fouribnb.lodge.presentation.dto.response.GetLodgeResponseDto;
 import com.fouribnb.lodge.presentation.dto.response.UpdateLodgeResponseDto;
 import com.fourirbnb.common.response.BaseResponse;
 import com.fourirbnb.common.response.Pagination;
+import com.fourirbnb.common.security.AuthenticatedUser;
+import com.fourirbnb.common.security.RoleCheck;
+import com.fourirbnb.common.security.UserInfo;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -78,23 +81,41 @@ public class LodgeController {
     }
 
     //객실삭제
-
     @DeleteMapping("/{lodgeId}")
     public ResponseEntity<Void> deleteLodge(@PathVariable UUID lodgeId) {
         lodgeService.deleteLodge(lodgeId);
         return ResponseEntity.noContent().build();
     }
 
+
+    /// api/lodges/{userId}
     //host객실목록조회
-    ///api/lodges/{userId}
+    @RoleCheck("Master")
+    @GetMapping("/lodges/me")
+    public BaseResponse<List<GetLodgeResponseDto>> getHostLodges(Pageable pageable,
+            @AuthenticatedUser UserInfo userInfo) {
+        Page<GetLodgeResponseDto> page = lodgeService.getHostLodges(pageable, userInfo);
+
+        Pagination pagination = new Pagination(
+                page.getNumber(),
+                (long) page.getSize(),
+                page.getTotalPages(),
+                (int) page.getTotalElements()
+        );
+        return BaseResponse.SUCCESS(
+                page.getContent(),
+                "호스트_나의객실목록 조회 완료",
+                pagination
+        );
+    }
+
+
 
     //host객실목록조회(내부)
 
     //객실검색
     //api/lodges/search?
     //page=1&size=10&sortBy=createdAt&isAsc=true
-
-
 
 
 }

--- a/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
@@ -37,10 +37,11 @@ public class LodgeController {
 
     private final LodgeService lodgeService;
 
+    //todo: 권한체크
     @PostMapping
     public BaseResponse<CreateLodgeResponseDto> createLodge(
-            @RequestBody CreateLodgeRequestDto requestDto) {
-        CreateLodgeResponseDto responseDto = lodgeService.createLodge(requestDto);
+            @RequestBody CreateLodgeRequestDto requestDto, @AuthenticatedUser UserInfo userInfo) {
+        CreateLodgeResponseDto responseDto = lodgeService.createLodge(requestDto, userInfo);
         return BaseResponse.SUCCESS(responseDto, "객실 생성 완료", HttpStatus.OK.value());
         //todo: dto userId -> UserInfo로 변경예정
     }
@@ -54,6 +55,7 @@ public class LodgeController {
     }
 
     //객실수정
+    //todo: 권한체크
     @PatchMapping("/{lodgeId}")
     public BaseResponse<UpdateLodgeResponseDto> updateLodge(@PathVariable UUID lodgeId,
             @RequestBody UpdateLodgeRequestDto requestDto)
@@ -82,6 +84,7 @@ public class LodgeController {
     }
 
     //객실삭제
+    //todo: 권한체크
     @DeleteMapping("/{lodgeId}")
     public ResponseEntity<Void> deleteLodge(@PathVariable UUID lodgeId, @AuthenticatedUser UserInfo userInfo) {
         lodgeService.deleteLodge(lodgeId, userInfo);
@@ -91,6 +94,7 @@ public class LodgeController {
 
     /// api/lodges/{userId}
     //host객실목록조회
+    //todo: 권한체크
     @RoleCheck("Master")
     @GetMapping("/lodges/me")
     public BaseResponse<List<GetLodgeResponseDto>> getHostLodges(Pageable pageable,
@@ -111,8 +115,6 @@ public class LodgeController {
     }
 
 
-
-    //host객실목록조회(내부)
 
     //객실검색
     //api/lodges/search?

--- a/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
@@ -42,6 +42,7 @@ public class LodgeController {
             @RequestBody CreateLodgeRequestDto requestDto) {
         CreateLodgeResponseDto responseDto = lodgeService.createLodge(requestDto);
         return BaseResponse.SUCCESS(responseDto, "객실 생성 완료", HttpStatus.OK.value());
+        //todo: dto userId -> UserInfo로 변경예정
     }
 
     //객실단건조회
@@ -82,8 +83,8 @@ public class LodgeController {
 
     //객실삭제
     @DeleteMapping("/{lodgeId}")
-    public ResponseEntity<Void> deleteLodge(@PathVariable UUID lodgeId) {
-        lodgeService.deleteLodge(lodgeId);
+    public ResponseEntity<Void> deleteLodge(@PathVariable UUID lodgeId, @AuthenticatedUser UserInfo userInfo) {
+        lodgeService.deleteLodge(lodgeId, userInfo);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/controller/LodgeController.java
@@ -11,6 +11,7 @@ import com.fourirbnb.common.response.Pagination;
 import com.fourirbnb.common.security.AuthenticatedUser;
 import com.fourirbnb.common.security.RoleCheck;
 import com.fourirbnb.common.security.UserInfo;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -40,10 +41,9 @@ public class LodgeController {
     //todo: 권한체크
     @PostMapping
     public BaseResponse<CreateLodgeResponseDto> createLodge(
-            @RequestBody CreateLodgeRequestDto requestDto, @AuthenticatedUser UserInfo userInfo) {
+            @Valid @RequestBody CreateLodgeRequestDto requestDto, @AuthenticatedUser UserInfo userInfo) {
         CreateLodgeResponseDto responseDto = lodgeService.createLodge(requestDto, userInfo);
         return BaseResponse.SUCCESS(responseDto, "객실 생성 완료", HttpStatus.OK.value());
-        //todo: dto userId -> UserInfo로 변경예정
     }
 
     //객실단건조회
@@ -116,6 +116,7 @@ public class LodgeController {
 
 
 
+    //객실검색
     //객실검색
     //api/lodges/search?
     //page=1&size=10&sortBy=createdAt&isAsc=true

--- a/src/main/java/com/fouribnb/lodge/presentation/dto/request/CreateLodgeRequestDto.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/dto/request/CreateLodgeRequestDto.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 @Builder
 public class CreateLodgeRequestDto {
 
-    private Long hostId;
     private String lodgeName;
     private RoomType roomType;
     private int capacity;

--- a/src/main/java/com/fouribnb/lodge/presentation/dto/request/CreateLodgeRequestDto.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/dto/request/CreateLodgeRequestDto.java
@@ -2,6 +2,7 @@ package com.fouribnb.lodge.presentation.dto.request;
 
 import com.fouribnb.lodge.domain.entity.Amenities;
 import com.fouribnb.lodge.domain.entity.RoomType;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,11 +10,21 @@ import lombok.Getter;
 @Builder
 public class CreateLodgeRequestDto {
 
+    @NotBlank
     private String lodgeName;
+
+    @NotBlank
     private RoomType roomType;
+
+    @NotBlank
     private int capacity;
+
+    @NotBlank
     private String address;
+
+    @NotBlank
     private Long pricePerNight;
+
     private String description;
     private Amenities amenities;
 }

--- a/src/main/java/com/fouribnb/lodge/presentation/dto/request/UpdateLodgeRequestDto.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/dto/request/UpdateLodgeRequestDto.java
@@ -11,7 +11,7 @@ public class UpdateLodgeRequestDto {
 
     private String lodgeName;
     private RoomType roomType;
-    private int capacity;
+    private Integer capacity;
     private String address;
     private Long pricePerNight;
     private String description;

--- a/src/main/java/com/fouribnb/lodge/presentation/mapper/LodgeMapper.java
+++ b/src/main/java/com/fouribnb/lodge/presentation/mapper/LodgeMapper.java
@@ -9,10 +9,10 @@ import com.fouribnb.lodge.presentation.dto.response.UpdateLodgeResponseDto;
 
 public class LodgeMapper {
 
-    public static Lodge createToEntity(CreateLodgeRequestDto dto) {
+    public static Lodge createToEntity(CreateLodgeRequestDto dto, Long currentHostId) {
         return Lodge.builder()
                 .lodgeName(dto.getLodgeName())
-                .hostId(dto.getHostId())
+                .hostId(currentHostId)
                 .roomType(dto.getRoomType())
                 .address(dto.getAddress())
                 .capacity(dto.getCapacity())


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
    * 호스트_나의객실조회 기능 생성
    * 일부 리팩토링

* **세부 내용**
    *  호스트_나의객실조회 api 생성
    * 객실삭제시 delete_by 에 들어가는 id host_id(db)-> currentHostId(Auth)로 변경
    * valid 추가
    * 객실수정시 입력된 항목만 수정



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 호스트 사용자를 위한 내 숙소 목록 조회 엔드포인트(/lodges/me)가 추가되었습니다. 해당 기능은 "Master" 역할의 사용자만 이용할 수 있으며, 본인 소유의 숙소를 페이지네이션 형태로 확인할 수 있습니다.

- **버그 수정**
    - 숙소 정보 수정 시, 입력값이 있을 때만 해당 필드가 업데이트되도록 개선되었습니다.

- **개선 사항**
    - 숙소 등록 및 삭제 시 사용자 인증이 적용되어, 로그인된 사용자만 해당 작업을 수행할 수 있습니다.
    - 숙소 등록 요청 시 호스트 ID를 직접 입력하지 않아도 되며, 필수 입력값에 대한 유효성 검사가 강화되었습니다.
    - 숙소 정보 수정 요청에서 인원(capacity) 필드가 선택 입력으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->